### PR TITLE
Simplify determining current character kind

### DIFF
--- a/src/construct/gfm_autolink_literal.rs
+++ b/src/construct/gfm_autolink_literal.rs
@@ -148,7 +148,7 @@ use crate::event::{Event, Kind, Name};
 use crate::state::{Name as StateName, State};
 use crate::tokenizer::Tokenizer;
 use crate::util::{
-    char::{kind_after_index, Kind as CharacterKind},
+    char::Kind as CharacterKind,
     slice::{Position, Slice},
 };
 use alloc::vec::Vec;
@@ -366,9 +366,7 @@ pub fn domain_inside(tokenizer: &mut Tokenizer) -> State {
         }
         _ => {
             // Source: <https://github.com/github/cmark-gfm/blob/ef1cfcb/extensions/autolink.c#L12>.
-            if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Other
-            {
+            if tokenizer.current_kind() == CharacterKind::Other {
                 tokenizer.tokenize_state.seen = true;
                 tokenizer.consume();
                 State::Next(StateName::GfmAutolinkLiteralDomainInside)
@@ -470,9 +468,7 @@ pub fn path_inside(tokenizer: &mut Tokenizer) -> State {
         }
         _ => {
             // Source: <https://github.com/github/cmark-gfm/blob/ef1cfcb/extensions/autolink.c#L12>.
-            if tokenizer.current.is_none()
-                || kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                    == CharacterKind::Whitespace
+            if tokenizer.current.is_none() || tokenizer.current_kind() == CharacterKind::Whitespace
             {
                 State::Retry(StateName::GfmAutolinkLiteralPathAfter)
             } else {
@@ -544,9 +540,7 @@ pub fn trail(tokenizer: &mut Tokenizer) -> State {
         }
         _ => {
             // Whitespace is the end of the URL, anything else is continuation.
-            if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Whitespace
-            {
+            if tokenizer.current_kind() == CharacterKind::Whitespace {
                 State::Ok
             } else {
                 State::Nok

--- a/src/construct/partial_mdx_jsx.rs
+++ b/src/construct/partial_mdx_jsx.rs
@@ -167,7 +167,7 @@ use crate::tokenizer::Tokenizer;
 use crate::util::{
     char::{
         after_index as char_after_index, format_byte, format_opt as format_char_opt,
-        kind_after_index, Kind as CharacterKind,
+        Kind as CharacterKind,
     },
     identifier::{id_cont, id_start},
 };
@@ -304,8 +304,7 @@ pub fn closing_tag_name_before(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn primary_name(tokenizer: &mut Tokenizer) -> State {
     // End of name.
-    if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-        == CharacterKind::Whitespace
+    if tokenizer.current_kind() == CharacterKind::Whitespace
         || matches!(tokenizer.current, Some(b'.' | b'/' | b':' | b'>' | b'{'))
     {
         tokenizer.exit(Name::MdxJsxTagNamePrimary);
@@ -418,8 +417,7 @@ pub fn member_name_before(tokenizer: &mut Tokenizer) -> State {
 pub fn member_name(tokenizer: &mut Tokenizer) -> State {
     // End of name.
     // Note: no `:` allowed here.
-    if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-        == CharacterKind::Whitespace
+    if tokenizer.current_kind() == CharacterKind::Whitespace
         || matches!(tokenizer.current, Some(b'.' | b'/' | b'>' | b'{'))
     {
         tokenizer.exit(Name::MdxJsxTagNameMember);
@@ -530,8 +528,7 @@ pub fn local_name_before(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn local_name(tokenizer: &mut Tokenizer) -> State {
     // End of local name (note that we don’t expect another colon, or a member).
-    if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-        == CharacterKind::Whitespace
+    if tokenizer.current_kind() == CharacterKind::Whitespace
         || matches!(tokenizer.current, Some(b'/' | b'>' | b'{'))
     {
         tokenizer.exit(Name::MdxJsxTagNameLocal);
@@ -668,8 +665,7 @@ pub fn attribute_expression_after(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn attribute_primary_name(tokenizer: &mut Tokenizer) -> State {
     // End of attribute name or tag.
-    if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-        == CharacterKind::Whitespace
+    if tokenizer.current_kind() == CharacterKind::Whitespace
         || matches!(tokenizer.current, Some(b'/' | b':' | b'=' | b'>' | b'{'))
     {
         tokenizer.exit(Name::MdxJsxTagAttributePrimaryName);
@@ -735,8 +731,7 @@ pub fn attribute_primary_name_after(tokenizer: &mut Tokenizer) -> State {
         }
         _ => {
             // End of tag / new attribute.
-            if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Whitespace
+            if tokenizer.current_kind() == CharacterKind::Whitespace
                 || matches!(tokenizer.current, Some(b'/' | b'>' | b'{'))
                 || id_start_opt(char_after_index(
                     tokenizer.parse_state.bytes,
@@ -792,8 +787,7 @@ pub fn attribute_local_name_before(tokenizer: &mut Tokenizer) -> State {
 /// ```
 pub fn attribute_local_name(tokenizer: &mut Tokenizer) -> State {
     // End of local name (note that we don’t expect another colon).
-    if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-        == CharacterKind::Whitespace
+    if tokenizer.current_kind() == CharacterKind::Whitespace
         || matches!(tokenizer.current, Some(b'/' | b'=' | b'>' | b'{'))
     {
         tokenizer.exit(Name::MdxJsxTagAttributeNameLocal);
@@ -1038,9 +1032,7 @@ pub fn es_whitespace_start(tokenizer: &mut Tokenizer) -> State {
             State::Next(StateName::MdxJsxEsWhitespaceEolAfter)
         }
         _ => {
-            if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Whitespace
-            {
+            if tokenizer.current_kind() == CharacterKind::Whitespace {
                 tokenizer.enter(Name::MdxJsxEsWhitespace);
                 State::Retry(StateName::MdxJsxEsWhitespaceInside)
             } else {
@@ -1070,10 +1062,7 @@ pub fn es_whitespace_inside(tokenizer: &mut Tokenizer) -> State {
             tokenizer.consume();
             State::Next(StateName::MdxJsxEsWhitespaceInside)
         }
-        Some(_)
-            if kind_after_index(tokenizer.parse_state.bytes, tokenizer.point.index)
-                == CharacterKind::Whitespace =>
-        {
+        Some(_) if tokenizer.current_kind() == CharacterKind::Whitespace => {
             tokenizer.consume();
             State::Next(StateName::MdxJsxEsWhitespaceInside)
         }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -655,6 +655,14 @@ impl<'a> Tokenizer<'a> {
 
         Ok(value)
     }
+
+    /// Returns the character kind at the current position.
+    ///
+    /// The `index` argument should be a character boundaries.
+    /// If it is not a charactar boundary, this function may return a character that does not actually exist in the source.
+    pub(crate) fn current_kind(&self) -> crate::util::char::Kind {
+        crate::util::char::kind_after_index(self.parse_state.bytes, self.point.index)
+    }
 }
 
 /// Move back past ignored bytes.

--- a/src/util/char.rs
+++ b/src/util/char.rs
@@ -49,6 +49,9 @@ pub fn before_index(bytes: &[u8], index: usize) -> Option<char> {
 ///
 /// In most cases, markdown operates on ASCII bytes.
 /// In a few cases, it is unicode aware, so we need to find an actual char.
+///
+/// The `index` argument should be a character boundaries.
+/// If it is not a charactar boundary, this function may return a character that does not actually exist in the source.
 pub fn after_index(bytes: &[u8], index: usize) -> Option<char> {
     let end = if index + 4 > bytes.len() {
         bytes.len()
@@ -59,7 +62,10 @@ pub fn after_index(bytes: &[u8], index: usize) -> Option<char> {
 }
 
 /// Classify a char at `index` in bytes (`&[u8]`).
-pub fn kind_after_index(bytes: &[u8], index: usize) -> Kind {
+///
+/// The `index` argument should be a character boundaries.
+/// If it is not a charactar boundary, this function may return a character that does not actually exist in the source.
+pub(crate) fn kind_after_index(bytes: &[u8], index: usize) -> Kind {
     if index == bytes.len() {
         Kind::Whitespace
     } else {


### PR DESCRIPTION
This change

- allows writing `tokenizer.current_kind()` instead of `crate::util::kind_after_index(tokenizer.parser_state.bytes, tokenizer.point.index)`
- documents the character boundary precondition of some functions
- explicitly limits the visibility of the util::kind_after_index to the crate (which is not exported and now can not be exported)